### PR TITLE
Bottom Layout Style

### DIFF
--- a/ButteryToast/Toaster.swift
+++ b/ButteryToast/Toaster.swift
@@ -8,6 +8,12 @@
 
 import UIKit
 
+// defines the orientation of presented toasts
+public enum Orientation {
+  case top
+  case bottom
+}
+
 /**
  Toaster manages a queue of Toasts in OperationQueue (FIFO)
  */
@@ -16,6 +22,9 @@ open class Toaster {
   open static let shared = Toaster()
   
   open var window: UIWindow?
+  
+  // set the toast orientation to top by default
+  open var orientation: Orientation = .top
   
   open func add(_ toast: Toast) {
     toast.toaster = self

--- a/ButteryToastExample/FirstViewController.swift
+++ b/ButteryToastExample/FirstViewController.swift
@@ -14,12 +14,13 @@ class FirstViewController: UIViewController {
   @IBAction func successPressed(_ sender: UIButton) {
     let successToastView = UINib(nibName: "SuccessToast", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as! UIView
     let successToast = Toast(view: successToastView)
+    Toaster.shared.orientation = .bottom
     Toaster.shared.add(successToast)
   }
 
   @IBAction func failurePressed(_ sender: UIButton) {
     let failureToastView = UINib(nibName: "FailureToast", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as! UIView
-    let failureToast = Toast(view: failureToastView)
+    let failureToast = Toast(view: failureToastView, orientation: .top)
     
     Toaster.shared.add(failureToast)
   }

--- a/ButteryToastExample/ModalViewController.swift
+++ b/ButteryToastExample/ModalViewController.swift
@@ -17,13 +17,13 @@ class ModalViewController: UIViewController {
 
   @IBAction func successPressed(_ sender: UIButton) {
     let successToastView = UINib(nibName: "SuccessToast", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as! UIView
-    let successToast = Toast(view: successToastView)
+    let successToast = Toast(view: successToastView, orientation: .top)
     Toaster.shared.add(successToast)
   }
 
   @IBAction func failurePressed(_ sender: UIButton) {
     let failureToastView = UINib(nibName: "FailureToast", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as! UIView
-    let failureToast = Toast(view: failureToastView)
+    let failureToast = Toast(view: failureToastView, orientation: .bottom)
     Toaster.shared.add(failureToast)
   }
 

--- a/ButteryToastExample/SecondViewController.swift
+++ b/ButteryToastExample/SecondViewController.swift
@@ -19,7 +19,7 @@ class SecondViewController: UIViewController {
 
   @IBAction func failurePressed(_ sender: UIButton) {
     let faliureToastView = UINib(nibName: "FailureToast", bundle: nil).instantiate(withOwner: nil, options: nil)[0] as! UIView
-    let failureToast = Toast(view: faliureToastView)
+    let failureToast = Toast(view: faliureToastView, orientation: .bottom)
     Toaster.shared.add(failureToast)
   }
 }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ class ToastyViewController: UIViewController {
 }
 ```
 
+### Presentation Options
+ Toasters have a variable `orientation` to determine the presentation style of their toasts.  This value is set to `top` by default.
+ Toasts also can be initialized with an `orientation`  which overrides the `Toaster` level `orientation`.  Currently `top` and `bottom` are the options for `orientation`.
 
 ## Installation
 


### PR DESCRIPTION
Toaster now has an enum to define the orientation of toasts.  Toasts can be given their own orientation when created or given nil to use the orientation defined at the Toaster level.  Toasters are given a `top` orientation by default but this value can be set on the shared instance.